### PR TITLE
Fix savedIncludes functionality on session restore

### DIFF
--- a/src/js/spider.js
+++ b/src/js/spider.js
@@ -391,7 +391,7 @@
 
   if (savedIncludes.length > 0) {
     for (var i = 0; i < savedIncludes.length; ++i) {
-      var filename = savedIncludes[i];
+      var filepath = savedIncludes[i];
 
       var li = document.createElement('li');
       li.classList.add('list-group-item');
@@ -402,14 +402,14 @@
       close.textContent = '\u00D7';
       close.onclick = (function() {
         return (function() {
-          delete localStorage[filename];
+          delete localStorage[filepath];
           includes.removeChild(li);
         });
       })();
 
       var display = document.createElement('ol');
 
-      filename = filename.split('/');
+      var filename = filepath.split('/');
       filename.shift();
 
       if (filename[0] === 'extra') {


### PR DESCRIPTION
#6 
There's a few other ways to go about this e.g. setting data-filepath on the element itself so it stores its own filepath before we start making changes to that path, or performing the processing into the filename beforehand then appending '/extra/' as the other include handling part does.